### PR TITLE
When the websocket is broken gracefully reload the site.

### DIFF
--- a/justpy/templates/js/event_handler.js
+++ b/justpy/templates/js/event_handler.js
@@ -133,8 +133,7 @@ function send_to_server(e, event_type, debug_flag) {
     }
     if (use_websockets) {
         if (web_socket_closed) {
-            let ok_to_reload = confirm('Page needs to be reloaded, click OK to reload');
-            if (ok_to_reload) window.location.reload();
+            reload_site();
             return;
         }
         if (websocket_ready) {

--- a/justpy/templates/main.html
+++ b/justpy/templates/main.html
@@ -3,6 +3,30 @@
 {% endfor %}
 
 <script>
+    let reload_timeout = 2000;
+    let reload_started = false;
+
+    function try_reload_site() {
+        fetch(window.location)
+        .then(function(response) {
+            console.log('Site Available, reloading');
+            window.location.reload();
+        })
+        .catch(function(error) {
+            console.log('Site Unavailable (', error.message, '), retrying in ', reload_timeout, 'ms');
+            setTimeout(try_reload_site, reload_timeout);
+            if (reload_timeout < 60000)
+                reload_timeout += 1000;
+        });
+    }
+
+    function reload_site() {
+        if (!reload_started) {
+            console.log("Reloading site...");
+            reload_started = true;
+            setTimeout(try_reload_site, reload_timeout);
+        }
+    }
 
     {% if page_options.redirect %}
         location.href = '{{ page_options.redirect }}';
@@ -72,11 +96,11 @@
         } else {
             protocol_string = 'ws://'
         }
+        var ws_url = protocol_string + document.domain;
         if (location.port) {
-            var socket = new WebSocket(protocol_string + document.domain + ':' + location.port);
-        } else {
-            var socket = new WebSocket(protocol_string + document.domain);
+            ws_url += ':' + location.port;
         }
+        var socket = new WebSocket(ws_url);
 
         socket.addEventListener('open', function (event) {
             console.log('Webocket opened');
@@ -84,18 +108,14 @@
         });
 
         socket.addEventListener('error', function (event) {
-            console.log('Websocket closed');
-            let ok_to_reload = confirm('Page needs to be reloaded, click OK to reload');
-            if (ok_to_reload) window.location.reload();
-            // setTimeout(function(){ window.location.reload(); }, 3000);
+            reload_site();
         });
 
         var web_socket_closed = false;
         socket.addEventListener('close', function (event) {
             console.log('Websocket closed');
             web_socket_closed = true;
-            let ok_to_reload = confirm('Page needs to be reloaded, click OK to reload');
-            if (ok_to_reload) window.location.reload()
+            reload_site()
         });
 
         socket.addEventListener('message', function (event) {


### PR DESCRIPTION
When the websocket is broken, the site currently displays an alert dialog asking the user to reload the page.

This patch gracefully tries to reload the site, backing off to 1 minute per retry.