### PR TITLE
Fix URL generation to better support serving behind proxy

### DIFF
--- a/justpy/justpy.py
+++ b/justpy/justpy.py
@@ -226,7 +226,7 @@ class Homepage(HTTPEndpoint):
         return JSONResponse(False)
 
 
-@app.websocket_route("/")
+@app.websocket_route("/", name="ws")
 class JustpyEvents(WebSocketEndpoint):
 
     socket_id = 0

--- a/justpy/templates/highcharts.html
+++ b/justpy/templates/highcharts.html
@@ -48,7 +48,7 @@
     {#Must be last#}
     <script src="https://code.highcharts.com/stock/modules/boost.js"></script>
 {% else %}
-    <script src="/templates/local/highcharts.js"></script>
+    <script src="{{ url_for('templates', path='/local/highcharts.js') }}"></script>
 {% endif %}
 
 

--- a/justpy/templates/main.html
+++ b/justpy/templates/main.html
@@ -72,11 +72,8 @@
         } else {
             protocol_string = 'ws://'
         }
-        if (location.port) {
-            var socket = new WebSocket(protocol_string + document.domain + ':' + location.port);
-        } else {
-            var socket = new WebSocket(protocol_string + document.domain);
-        }
+        const wsURL = '{{ url_for('ws') }}';
+        var socket = new WebSocket(wsURL);
 
         socket.addEventListener('open', function (event) {
             console.log('Webocket opened');

--- a/justpy/templates/optional_packages.html
+++ b/justpy/templates/optional_packages.html
@@ -6,7 +6,7 @@
     {% if not options.no_internet %}
         <script src="https://unpkg.com/ag-grid-community/dist/ag-grid-community.min.js"></script>
     {% else %}
-        <script src="/templates/local/ag-grid-community.js"></script>
+        <script src="{{ url_for('templates', path='/local/ag-grid-community.js') }}"></script>
     {% endif %}
 {% endif %}
 
@@ -14,7 +14,7 @@
     {% if not options.no_internet %}
         <script src="https://unpkg.com/ag-grid-enterprise/dist/ag-grid-enterprise.min.js"></script>
     {% else %}
-        <script src="/templates/local/ag-grid-enterprise.js"></script>
+        <script src="{{ url_for('templates', path='/local/ag-grid-enterprise.js') }}"></script>
     {% endif %}
 {% endif %}
 

--- a/justpy/templates/quasar.html
+++ b/justpy/templates/quasar.html
@@ -11,10 +11,10 @@
                 <link rel="stylesheet" href="https://unpkg.com/@tailwindcss/typography@0.4.x/dist/typography.min.css">
                 <link rel="stylesheet" href="https://unpkg.com/tailwindcss@^2.0/dist/utilities.min.css">
             {% else %}
-                <link href="/templates/local/tailwind/base.css" rel="stylesheet">
-                <link href="/templates/local/tailwind/components.css" rel="stylesheet">
-                <link href="/templates/local/tailwind/typography.css" rel="stylesheet">
-                <link href="/templates/local/tailwind/utilities.css" rel="stylesheet">
+                <link href="{{ url_for('templates', path='/local/tailwind/base.css') }}" rel="stylesheet">
+                <link href="{{ url_for('templates', path='/local/tailwind/components.css') }}" rel="stylesheet">
+                <link href="{{ url_for('templates', path='/local/tailwind/typography.css') }}" rel="stylesheet">
+                <link href="{{ url_for('templates', path='/local/tailwind/utilities.css') }}" rel="stylesheet">
             {% endif %}
             <style>
                 {% include 'css/form.css' %}
@@ -36,12 +36,12 @@
                   type="text/css">
         {% endif %}
     {% else %}
-        <link rel="stylesheet" href="/templates/local/robotofont/robotofont.css"/>
-        <link rel="stylesheet" href="/templates/local/ionicons/ionicons.css"/>
-        <link rel="stylesheet" href="/templates/local/materialdesignicons/iconfont/material-icons.css"/>
-        <link rel="stylesheet" href="/templates/local/fontawesome/css/all.min.css"/>
-        <link rel="stylesheet" href="/templates/local/animate.css"/>
-        <link rel="stylesheet" href="/templates/local/quasar.css"/>
+        <link rel="stylesheet" href="{{ url_for('templates', path='/local/robotofont/robotofont.css') }}"/>
+        <link rel="stylesheet" href="{{ url_for('templates', path='/local/ionicons/ionicons.css') }}"/>
+        <link rel="stylesheet" href="{{ url_for('templates', path='/local/materialdesignicons/iconfont/material-icons.css') }}"/>
+        <link rel="stylesheet" href="{{ url_for('templates', path='/local/fontawesome/css/all.min.css') }}"/>
+        <link rel="stylesheet" href="{{ url_for('templates', path='/local/animate.css') }}"/>
+        <link rel="stylesheet" href="{{ url_for('templates', path='/local/quasar.css') }}"/>
     {% endif %}
 
     <style>
@@ -71,9 +71,9 @@
         {% endif %}
 
     {% else %}
-        <script src="/templates/local/jquery.js"></script>
-        <script src="/templates/local/vue.js"></script>
-        <script src="/templates/local/quasar.js"></script>
+        <script src="{{ url_for('templates', path='/local/jquery.js') }}"></script>
+        <script src="{{ url_for('templates', path='/local/vue.js') }}"></script>
+        <script src="{{ url_for('templates', path='/local/quasar.js') }}"></script>
     {% endif %}
 
     <div id="components">

--- a/justpy/templates/tailwind.html
+++ b/justpy/templates/tailwind.html
@@ -12,10 +12,10 @@
                 <link rel="stylesheet" href="https://unpkg.com/@tailwindcss/typography@0.4.x/dist/typography.min.css">
                 <link rel="stylesheet" href="https://unpkg.com/tailwindcss@^2.0/dist/utilities.min.css">
             {% else %}
-                <link href="/templates/local/tailwind/base.css" rel="stylesheet">
-                <link href="/templates/local/tailwind/components.css" rel="stylesheet">
-                <link href="/templates/local/tailwind/typography.css" rel="stylesheet">
-                <link href="/templates/local/tailwind/utilities.css" rel="stylesheet">
+                <link href="{{ url_for('templates', path='/local/tailwind/base.css') }}" rel="stylesheet">
+                <link href="{{ url_for('templates', path='/local/tailwind/components.css') }}" rel="stylesheet">
+                <link href="{{ url_for('templates', path='/local/tailwind/typography.css') }}" rel="stylesheet">
+                <link href="{{ url_for('templates', path='/local/tailwind/utilities.css') }}" rel="stylesheet">
             {% endif %}
             <style>
                 {% include 'css/form.css' %}
@@ -27,8 +27,8 @@
             <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.9.0/css/all.css"/>
             <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css"/>
         {% else %}
-            <link rel="stylesheet" href="/templates/local/fontawesome/css/all.min.css"/>
-            <link rel="stylesheet" href="/templates/local/animate.css"/>
+            <link rel="stylesheet" href="{{ url_for('templates', path='/local/fontawesome/css/all.min.css') }}"/>
+            <link rel="stylesheet" href="{{ url_for('templates', path='/local/animate.css') }}"/>
         {% endif %}
 
         <style>
@@ -42,8 +42,8 @@
                 <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
                 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.min.js"></script>
             {% else %}
-                <script src="/templates/local/jquery.js"></script>
-                <script src="/templates/local/vue.js"></script>
+                <script src="{{ url_for('templates', path='/local/jquery.js') }}"></script>
+                <script src="{{ url_for('templates', path='/local/vue.js') }}"></script>
             {% endif %}
         {% endif %}
 

--- a/justpy/templates/tailwindui.html
+++ b/justpy/templates/tailwindui.html
@@ -10,8 +10,8 @@
                 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tailwindcss/ui@latest/dist/tailwind-ui.min.css">
                 <link rel="stylesheet" href="https://unpkg.com/@tailwindcss/typography@/dist/typography.min.css">
             {% else %}
-                <link href="/templates/local/tailwindui.css" rel="stylesheet">
-                <link href="/templates/local/tailwind/typography.css" rel="stylesheet">
+                <link href="{{ url_for('templates', path='/local/tailwindui.css') }}" rel="stylesheet">
+                <link href="{{ url_for('templates', path='/local/tailwind/typography.css') }}" rel="stylesheet">
 
             {% endif %}
             <style>
@@ -24,8 +24,8 @@
             <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.9.0/css/all.css"/>
             <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css"/>
         {% else %}
-            <link rel="stylesheet" href="/templates/local/fontawesome/css/all.min.css"/>
-            <link rel="stylesheet" href="/templates/local/animate.css"/>
+            <link rel="stylesheet" href="{{ url_for('templates', path='/local/fontawesome/css/all.min.css') }}"/>
+            <link rel="stylesheet" href="{{ url_for('templates', path='/local/animate.css') }}"/>
         {% endif %}
 
         <style>
@@ -39,8 +39,8 @@
                 <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
                 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.min.js"></script>
             {% else %}
-                <script src="/templates/local/jquery.js"></script>
-                <script src="/templates/local/vue.js"></script>
+                <script src="{{ url_for('templates', path='/local/jquery.js') }}"></script>
+                <script src="{{ url_for('templates', path='/local/vue.js') }}"></script>
             {% endif %}
         {% endif %}
 
@@ -52,7 +52,7 @@
             {% if not options.no_internet %}
                 <script src="https://unpkg.com/ag-grid-community/dist/ag-grid-community.min.js"></script>
             {% else %}
-                <script src="/templates/local/ag-grid-community.js"></script>
+                <script src="{{ url_for('templates', path='/local/ag-grid-community.js') }}"></script>
             {% endif %}
         {% endif %}
 
@@ -60,7 +60,7 @@
             {% if not options.no_internet %}
                 <script src="https://unpkg.com/ag-grid-enterprise/dist/ag-grid-enterprise.min.js"></script>
             {% else %}
-                <script src="/templates/local/ag-grid-enterprise.js"></script>
+                <script src="{{ url_for('templates', path='/local/ag-grid-enterprise.js') }}"></script>
             {% endif %}
         {% endif %}
     </head>


### PR DESCRIPTION
# Objective

Currently, it's very hard to serve a JustPy app behind a reverse proxy.

Typically, if we want to serve the JustPy app under a path prefix. In ASGI apps, this can be handled thanks to the `root_path` parameter. There is a very good rationale about this in the FastAPI documentation: https://fastapi.tiangolo.com/advanced/behind-a-proxy/

However, for this to work, we need to make sure every URL are generated properly, especially by using the [`url_for` function of Starlette](https://www.starlette.io/routing/#reverse-url-lookups).

Currently, there are many places where the URL is manually built.

# Changes

The presented changes try to solve this.

1. The URL of the WebSocket is now dynamically generated in the `main.html` script. For this to work, we had to add the `name` parameter to the WebSocket route.
2. Every CSS and JS static files in the `/templates/local` folder now have a dynamically generated URL.

Feel free to make some comments about this; I'll be happy to improve my proposal so it fits well in the project.